### PR TITLE
Extension Manifest for Firefox

### DIFF
--- a/LOAD_UNPACKED/manifest_v2
+++ b/LOAD_UNPACKED/manifest_v2
@@ -1,0 +1,34 @@
+{
+  "manifest_version": 2,
+  "name": "wplacer",
+  "version": "4.2",
+  "description": "Automatically sends session and Turnstile tokens from wplace.live to a wplacer server.",
+  "permissions": [
+    "storage",
+    "cookies",
+    "tabs",
+    "alarms",
+    "browsingData",
+    "https://wplace.live/*",
+    "https://backend.wplace.live/*",
+    "http://127.0.0.1/*"
+  ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  },
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/favicon-16x16.png",
+      "32": "icons/favicon-32x32.png"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://wplace.live/*"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ]
+}


### PR DESCRIPTION
Firefox does not yet fully support `background.service_worker`
Instead, Firefox still primarily uses Manifest V2 style `background.scripts`. Loading the current `manifest.json` results in this error `background.service_worker is currently disabled. Add background.scripts.`

This Manifest V2 file can be used for those who use Firefox