### PR TITLE
Fix template save file location

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,10 +34,10 @@ const WPLACE_PIXEL = (tx, ty) => `${WPLACE_BASE}/s0/pixel/${tx}/${ty}`;
 const WPLACE_PURCHASE = `${WPLACE_BASE}/purchase`;
 const TILE_URL = (tx, ty) => `${WPLACE_FILES}/tiles/${tx}/${ty}.png`;
 
-const DATA_DIR = './data';
+const DATA_DIR = path.join(__dirname, 'data');
 const USERS_FILE = 'users.json';
 const SETTINGS_FILE = 'settings.json';
-const TEMPLATES_PATH = path.join(__dirname, 'templates.json');
+const TEMPLATES_PATH = path.join(DATA_DIR, 'templates.json');
 
 const JSON_LIMIT = '50mb';
 


### PR DESCRIPTION
The following commit has modified where the `templates.json` file is being saved.
https://github.com/luluwaffless/wplacer/pull/226/commits/8091253ebf09e5e9faeed0cfb1e5446f1bf67301

The relevant part is:
```
const __filename = fileURLToPath(import.meta.url);
const __dirname = path.dirname(__filename);
[...]
const DATA_DIR = './data';
const USERS_FILE = 'users.json';
const SETTINGS_FILE = 'settings.json';
const TEMPLATES_PATH = path.join(__dirname, 'templates.json');
```

As you can see, right now, `TEMPLATES_PATH` points to `root/templates.json`.
The correct path should be `root/data/templates.json`.

Because of this, templates can still be loaded, but any changes are saved to the new file in the root directory, so when you restart the app changes appear to have not persisted.